### PR TITLE
DTO에 붙은 불필요한 Serializable 인터페이스 제거

### DIFF
--- a/src/main/java/com/yoon/projectboard/dto/response/ArticleCommentResponse.java
+++ b/src/main/java/com/yoon/projectboard/dto/response/ArticleCommentResponse.java
@@ -2,7 +2,6 @@ package com.yoon.projectboard.dto.response;
 
 import com.yoon.projectboard.dto.ArticleCommentDto;
 
-import java.io.Serializable;
 import java.time.LocalDateTime;
 
 public record ArticleCommentResponse(
@@ -11,7 +10,7 @@ public record ArticleCommentResponse(
         LocalDateTime createdAt,
         String email,
         String nickname
-) implements Serializable {
+) {
     public static ArticleCommentResponse of(Long id, String content, LocalDateTime createdAt, String email, String nickname) {
         return new ArticleCommentResponse(id, content, createdAt, email, nickname);
     }


### PR DESCRIPTION
프로젝트에서는 직렬화로 `Jackson`을 사용하므로 `Serializable` 은 필요 없으므로 삭제